### PR TITLE
split bind into three files and copy custom bindings from appsdk

### DIFF
--- a/bind_composable.go
+++ b/bind_composable.go
@@ -1,8 +1,6 @@
 package kindsys
 
-import (
-	"github.com/grafana/thema"
-)
+import "github.com/grafana/thema"
 
 // genericComposable is a general representation of a parsed and validated
 // Composable kind.
@@ -45,51 +43,6 @@ func BindComposable(rt *thema.Runtime, def Def[ComposableProperties], opts ...th
 	}
 
 	return genericComposable{
-		def: def,
-		lin: lin,
-	}, nil
-}
-
-// genericCore is a general representation of a parsed and validated Core kind.
-type genericCore struct {
-	def Def[CoreProperties]
-	lin thema.Lineage
-}
-
-var _ Core = genericCore{}
-
-func (k genericCore) Props() SomeKindProperties {
-	return k.def.Properties
-}
-
-func (k genericCore) Name() string {
-	return k.def.Properties.Name
-}
-
-func (k genericCore) MachineName() string {
-	return k.def.Properties.MachineName
-}
-
-func (k genericCore) Maturity() Maturity {
-	return k.def.Properties.Maturity
-}
-
-func (k genericCore) Def() Def[CoreProperties] {
-	return k.def
-}
-
-func (k genericCore) Lineage() thema.Lineage {
-	return k.lin
-}
-
-// TODO docs
-func BindCore(rt *thema.Runtime, def Def[CoreProperties], opts ...thema.BindOption) (Core, error) {
-	lin, err := def.Some().BindKindLineage(rt, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return genericCore{
 		def: def,
 		lin: lin,
 	}, nil

--- a/bind_core.go
+++ b/bind_core.go
@@ -1,0 +1,50 @@
+package kindsys
+
+import (
+	"github.com/grafana/thema"
+)
+
+// genericCore is a general representation of a parsed and validated Core kind.
+type genericCore struct {
+	def Def[CoreProperties]
+	lin thema.Lineage
+}
+
+var _ Core = genericCore{}
+
+func (k genericCore) Props() SomeKindProperties {
+	return k.def.Properties
+}
+
+func (k genericCore) Name() string {
+	return k.def.Properties.Name
+}
+
+func (k genericCore) MachineName() string {
+	return k.def.Properties.MachineName
+}
+
+func (k genericCore) Maturity() Maturity {
+	return k.def.Properties.Maturity
+}
+
+func (k genericCore) Def() Def[CoreProperties] {
+	return k.def
+}
+
+func (k genericCore) Lineage() thema.Lineage {
+	return k.lin
+}
+
+// TODO docs
+func BindCore(rt *thema.Runtime, def Def[CoreProperties], opts ...thema.BindOption) (Core, error) {
+	lin, err := def.Some().BindKindLineage(rt, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return genericCore{
+		def: def,
+		lin: lin,
+	}, nil
+}

--- a/bind_custom.go
+++ b/bind_custom.go
@@ -1,0 +1,58 @@
+package kindsys
+
+import (
+	"github.com/grafana/thema"
+)
+
+// genericCustom is a general representation of a parsed and validated Custom kind.
+type genericCustom struct {
+	def Def[CustomProperties]
+	lin thema.Lineage
+}
+
+var _ Custom = genericCustom{}
+
+// Props returns the generic SomeKindProperties
+func (k genericCustom) Props() SomeKindProperties {
+	return k.def.Properties
+}
+
+// Name returns the Name property
+func (k genericCustom) Name() string {
+	return k.def.Properties.Name
+}
+
+// MachineName returns the MachineName property
+func (k genericCustom) MachineName() string {
+	return k.def.Properties.MachineName
+}
+
+// Maturity returns the Maturity property
+func (k genericCustom) Maturity() Maturity {
+	return k.def.Properties.Maturity
+}
+
+// Def returns a Def with the type of ExtendedProperties, containing the bound ExtendedProperties
+func (k genericCustom) Def() Def[CustomProperties] {
+	return k.def
+}
+
+// Lineage returns the underlying bound Lineage
+func (k genericCustom) Lineage() thema.Lineage {
+	return k.lin
+}
+
+// BindCustom creates a Custom-implementing type from a def, runtime, and opts
+//
+//nolint:lll
+func BindCustom(rt *thema.Runtime, def Def[CustomProperties], opts ...thema.BindOption) (Custom, error) {
+	lin, err := def.Some().BindKindLineage(rt, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return genericCustom{
+		def: def,
+		lin: lin,
+	}, nil
+}


### PR DESCRIPTION
> // TODO: should this go in kindsys?

I saw that ^^ [TODO](https://github.com/grafana/grafana-app-sdk/blob/6a6e3aac318788a72755c17040fc7e6977420161/codegen/bind.go#L8) and thought: yes. yes it does. I also split the bind.go into three files, one for each of the categories (core|custom|composable).
