### PR TITLE
Updates to Custom kind for new schema format

### DIFF
--- a/kindcat_custom.cue
+++ b/kindcat_custom.cue
@@ -40,14 +40,8 @@ _crdSchema: {
 	// TODO: use CommonMetadata instead of redfining here; currently needs to be defined here 
 	// without extenal reference as using the CommonMetadata reference breaks thema codegen.
 	metadata: {
-		uid: string
-		creationTimestamp: string & time.Time
-		deletionTimestamp?: string & time.Time
-		finalizers: [...string]
-		resourceVersion: string
-		labels: {
-			[string]: string
-		}
+		_kubeObjectMetadata
+		
 		updateTimestamp: string & time.Time
 		createdBy: string
 		updatedBy: string
@@ -138,7 +132,7 @@ Custom: S={
 			if S.crd.groupOverride != _|_ {
 				strings.ToLower(S.crd.groupOverride) + ".apps.grafana.com",
 			}
-			strings.ToLower(strings.Replace(S.plugin.id, "-","_",-1)) + ".apps.grafana.com"
+			strings.ToLower(strings.Replace(S.pluginID, "-","_",-1)) + ".apps.grafana.com"
 		]
 
 		// group is used as the CRD group name in the GVK.
@@ -153,17 +147,6 @@ Custom: S={
 		// scope determines whether resources of this kind exist globally ("Cluster") or
 		// within Kubernetes namespaces.
 		scope: "Cluster" | *"Namespaced"
-
-		// deepCopy determines whether a generic implementation of copying should be
-		// generated, or a passthrough call to a Go function.
-		//   deepCopy: *"generic" | "passthrough"
-	}
-
-	// plugin contains data about the plugin which owns this custom kind
-	plugin: {
-		// id is the unique ID of the plugin
-		id: S.pluginID
-		// TODO: additional info?
 	}
 
 	// codegen contains properties specific to generating code using tooling

--- a/kindcat_custom.cue
+++ b/kindcat_custom.cue
@@ -102,7 +102,7 @@ _crdSchema: {
 Custom: S={
 	_sharedKind
 
-	// pluginID is the unique identifier of owner/grouping of this Custom kind
+	// group is the unique identifier of owner/grouping of this Custom kind
 	group: =~"^([a-z][a-z0-9-]*[a-z0-9])$"
 
 	// isCRD is true if the `crd` trait is present in the kind.
@@ -131,16 +131,18 @@ Custom: S={
 	// TODO: rather than `crd`, should this trait be something more generic, as it really indicates more if a resource should be available in a
 	// kubernetes-compatible APIServer, not specifically as CRD (though that _is_ an implementation)
 	crd?: {
-		// groupOverride is an override that is used in the crd trait if present.
-		// If left empty, plugin.id is used to generate the group name
-		groupOverride?: =~"^([a-z][a-z0-9-]{0,32}[a-z0-9])$"
+		// groupOverride is used to override the auto-generated group of "<group>.ext.grafana.com"
+		// if present, this value is used for the CRD group instead.
+		// groupOverride must have at least two parts (i.e. 'foo.bar'), but can be longer.
+		// The length of groupOverride + kind name cannot exceed 62 characters
+		groupOverride?: =~"^([a-z][a-z0-9-.]{0,48}[a-z0-9])\\.([a-z][a-z0-9-]{0,48}[a-z0-9])$"
 
 		// _computedGroups is a list of groups computed from information in the plugin trait.
 		// The first element is always the "most correct" one to use.
 		// This field could be inlined into `group`, but is separate for clarity.
 		_computedGroups: [
 			if S.crd.groupOverride != _|_ {
-				strings.ToLower(S.crd.groupOverride) + ".ext.grafana.com",
+				strings.ToLower(S.crd.groupOverride),
 			}
 			strings.ToLower(strings.Replace(S.group, "_","-",-1)) + ".ext.grafana.com"
 		]

--- a/kindcat_custom.cue
+++ b/kindcat_custom.cue
@@ -105,18 +105,19 @@ Custom: S={
 	isCRD: S.crd != _|_
 
 	lineage: { 
-		name: S.machineName 
+		name: S.machineName
+	}
+	lineageIsGroup: false
+
+	if isCRD {
 		// If the crd trait is defined, the schemas in the lineage must follow the format:
 		// {
 		//     "metadata": CommonMetadata & {...string}
 		//     "spec": {...}
 		//     "status": {...}
 		// }
-		if S.isCRD {
-			joinSchema: _crdSchema
-		}
+		lineage: joinSchema: _crdSchema
 	}
-	lineageIsGroup: false
 
 	// crd contains properties specific to converting this kind to a Kubernetes CRD.
 	// Unlike in Core, crd is optional and is used as a signaling mechanism for whether the kind is intended to be registered as a Kubernetes CRD 

--- a/kindcat_custom.cue
+++ b/kindcat_custom.cue
@@ -12,7 +12,7 @@ _kubeObjectMetadata: {
     uid: string
     creationTimestamp: string & time.Time
     deletionTimestamp?: string & time.Time
-    finalizers: [string]
+    finalizers: [...string]
     resourceVersion: string
     labels: {
         [string]: string
@@ -54,12 +54,33 @@ Custom: S={
 		// }
 		if S.crd != _|_ {
 			joinSchema: {
-				metadata: CommonMetadata & {
+				// metadata contains embedded CommonMetadata and can be extended with custom string fields
+				// TODO: use CommonMetadata instead of redfining here; currently needs to be defined here 
+				// without extenal reference as using the CommonMetadata reference breaks thema codegen.
+				metadata: {
+					uid: string
+					creationTimestamp: string & time.Time
+					deletionTimestamp?: string & time.Time
+					finalizers: [...string]
+					resourceVersion: string
+					labels: {
+						[string]: string
+					}
+					updateTimestamp: string & time.Time
+					createdBy: string
+					updatedBy: string
+
+					// TODO: additional metadata fields?
+					// Additional metadata can be added at any future point, as it is allowed to be constant across lineage versions
+
+					// extraFields is reserved for any fields that are pulled from the API server metadata but do not have concrete fields in the CUE metadata
+					extraFields: {...}
+				} & {
 					// All extensions to this metadata need to have string values (for APIServer encoding-to-annotations purposes)
 					// Can't use this as it's not yet enforced CUE:
 					//...string
 					// Have to do this gnarly regex instead
-					[!~"^(uid|creationTimestamp|deletionTimestamp|finalizers|resourceVersion|labels|updateTimestamp|createdBy|updatedBy)$"]: string
+					[!~"^(uid|creationTimestamp|deletionTimestamp|finalizers|resourceVersion|labels|updateTimestamp|createdBy|updatedBy|extraFields)$"]: string
 				}
 				spec: {...}
 				status: {...}

--- a/kindcat_custom.cue
+++ b/kindcat_custom.cue
@@ -118,7 +118,7 @@ Custom: S={
 		group: _computedGroups[0] & =~"^([a-z][a-z0-9_.]{0,61}[a-z0-9])$"
 
 		// _computedGroupKind checks the validity of the CRD kind + group
-		_computedGroupKind: S.machineName + "." + group =~"^([a-z][a-z0-9_.]{0,61}[a-z0-9])$"
+		_computedGroupKind: S.machineName + "." + group & =~"^([a-z][a-z0-9_.]{0,63}[a-z0-9])$"
 
 		// scope determines whether resources of this kind exist globally ("Cluster") or
 		// within Kubernetes namespaces.

--- a/kindcat_custom.cue
+++ b/kindcat_custom.cue
@@ -1,5 +1,35 @@
 package kindsys
 
+import (
+	"strings"
+	"time"	
+)
+
+// _kubeObjectMetadata is metadata found in a kubernetes object's metadata field.
+// It is not exhaustive and only includes fields which may be relevant to a kind's implementation,
+// As it is also intended to be generic enough to function with any API Server.
+_kubeObjectMetadata: {
+    uid: string
+    creationTimestamp: string & time.Time
+    deletionTimestamp?: string & time.Time
+    finalizers: [string]
+    resourceVersion: string
+    labels: {
+        [string]: string
+    }
+}
+
+// CommonMetadata is a combination of API Server metadata and additional metadata 
+// intended to exist commonly across all kinds, but may have varying implementations as to its storage mechanism(s).
+CommonMetadata: {
+    _kubeObjectMetadata
+
+    updateTimestamp: string & time.Time
+    createdBy: string
+    updatedBy: string
+	// TODO: additional metadata fields?
+}
+
 // Custom specifies the kind category for plugin-defined arbitrary types.
 // Custom kinds have the same purpose as Core kinds, differing only in
 // that they are defined by external plugins rather than in Grafana core. As such,
@@ -10,6 +40,61 @@ package kindsys
 Custom: S={
 	_sharedKind
 
-	lineage: { name: S.machineName }
+	// appID is the unique identifier of the app which is the owner of this Custom kind.
+	// TODO: should this just be pluginID? Is there a world where an app and plugin may not share the same ID?
+	// The practical reason to have it different is to allow the appID to be shorter than the pluginID as the group
+	// is generated from the appID, and <kind name>+<group> cannot exceed 63 characters in kubernetes.
+	appID: =~"^([a-z][a-z0-9-]{0,61}[a-z0-9])$"
+
+	lineage: { 
+		name: S.machineName 
+		// If the crd trait is defined, the schemas in the lineage must follow the format:
+		// {
+		//     "metadata": CommonMetadata & {...string}
+		//     "spec": {...}
+		//     "status": {...}
+		// }
+		if S.crd != _|_ {
+			joinSchema: {
+				metadata: CommonMetadata & {
+					// All extensions to this metadata need to have string values (for APIServer encoding-to-annotations purposes)
+					// Can't use this as it's not yet enforced CUE:
+					//...string
+					// Have to do this gnarly regex instead
+					[!~"^(uid|creationTimestamp|deletionTimestamp|finalizers|resourceVersion|labels|updateTimestamp|createdBy|updatedBy)$"]: string
+				}
+				spec: {...}
+				status: {...}
+			}
+		}
+	}
 	lineageIsGroup: false
+
+	// crd contains properties specific to converting this kind to a Kubernetes CRD.
+	// Unlike in Core, crd is optional and is used as a signaling mechanism for whether the kind is intended to be registered as a Kubernetes CRD 
+	// and/or a resource in a compatible API server. When present, additional structure is enforced on the kind's lineage's schemas.
+	// When absent, a lineage's schema has no restrictions as it is assumed that a CRD or similar resource type will not be generated from it.
+	// 
+	// TODO: rather than `crd`, should this trait be something more generic, as it really indicates more if a resource should be available in a
+	// kubernetes-compatible APIServer, not specifically as CRD (though that _is_ an implementation)
+	crd?: {
+		// group is used as the CRD group name in the GVK.
+		group: strings.ToLower(S.appID) + ".apps.grafana.com"
+
+		// scope determines whether resources of this kind exist globally ("Cluster") or
+		// within Kubernetes namespaces.
+		scope: "Cluster" | *"Namespaced"
+
+		// deepCopy determines whether a generic implementation of copying should be
+		// generated, or a passthrough call to a Go function.
+		//   deepCopy: *"generic" | "passthrough"
+	}
+
+	// codegen contains properties specific to generating code using tooling
+	codegen: {
+		// frontend indicates whether front-end TypeScript code should be generated for this kind's schema
+		frontend: bool | *true
+		// backend indicates whether back-end Go code should be generated for this kind's schema
+		backend: bool | *true
+	}
 }

--- a/props.go
+++ b/props.go
@@ -41,6 +41,18 @@ func (m CoreProperties) Common() CommonProperties {
 type CustomProperties struct {
 	CommonProperties
 	CurrentVersion thema.SyntacticVersion `json:"currentVersion"`
+	CRD            struct {
+		Group         string  `json:"group"`
+		Scope         string  `json:"scope"`
+		GroupOverride *string `json:"groupOverride"`
+	} `json:"crd"`
+	Plugin struct {
+		ID string `json:"id"`
+	} `json:"plugin"`
+	Codegen struct {
+		Frontend bool `json:"frontend"`
+		Backend  bool `json:"backend"`
+	} `json:"codegen"`
 }
 
 func (m CustomProperties) _private() {}

--- a/props.go
+++ b/props.go
@@ -41,14 +41,13 @@ func (m CoreProperties) Common() CommonProperties {
 type CustomProperties struct {
 	CommonProperties
 	CurrentVersion thema.SyntacticVersion `json:"currentVersion"`
+	IsCRD          bool                   `json:"isCRD"`
+	PluginID       string                 `json:"pluginID"`
 	CRD            struct {
 		Group         string  `json:"group"`
 		Scope         string  `json:"scope"`
 		GroupOverride *string `json:"groupOverride"`
 	} `json:"crd"`
-	Plugin struct {
-		ID string `json:"id"`
-	} `json:"plugin"`
 	Codegen struct {
 		Frontend bool `json:"frontend"`
 		Backend  bool `json:"backend"`

--- a/props.go
+++ b/props.go
@@ -42,7 +42,7 @@ type CustomProperties struct {
 	CommonProperties
 	CurrentVersion thema.SyntacticVersion `json:"currentVersion"`
 	IsCRD          bool                   `json:"isCRD"`
-	PluginID       string                 `json:"pluginID"`
+	Group          string                 `json:"group"`
 	CRD            struct {
 		Group         string  `json:"group"`
 		Scope         string  `json:"scope"`


### PR DESCRIPTION
Initial work on the Custom kind to enforce the new schema format, specifically when the kind as a `crd` trait.

If a Custom kind has the `crd` trait, then the lineage's schema enforces a specific format using joinSchema:
```cue
{
    metadata: CommonMetadata & {...string}
    spec: {...}
    status: CommonStatus & {...}
}
```

As part of adding the optional `crd` trait, the `appID` field was added to allow for generating the group (see TODO note about this).

Also as a part of this PR, a `codegen` trait was added, allowing app/plugin development tooling to know what kind of code to generate from this kind.