### PR TITLE
Return nil instead of UnaryLineage in BindKindLineage

### DIFF
--- a/somedef.go
+++ b/somedef.go
@@ -25,7 +25,7 @@ type SomeDef struct {
 // [thema.BindType].
 func (def SomeDef) BindKindLineage(rt *thema.Runtime, opts ...thema.BindOption) (thema.Lineage, error) {
 	if rt == nil {
-		return &thema.UnaryLineage{}, fmt.Errorf("nil thema.Runtime")
+		return nil, fmt.Errorf("nil thema.Runtime")
 	}
 	return thema.BindLineage(def.V.LookupPath(cue.MakePath(cue.Str("lineage"))), rt, opts...)
 }


### PR DESCRIPTION
UnaryLineage is going to disappear when we merge [flatten schemas PR](https://github.com/grafana/thema/pull/82). Return nil fixes the issue.