### PR TITLE
Make the crdSchema.status.additionalFields optional

### DIFF
--- a/kindcat_custom.cue
+++ b/kindcat_custom.cue
@@ -88,7 +88,7 @@ _crdSchema: {
 			[string]: #OperatorState
 		}
 		// additionalFields is reserved for future use
-		additionalFields: {
+		additionalFields?: {
 			[string]: _
 		}
 	} & {


### PR DESCRIPTION
Make the `crdSchema.status.additionalFields` not required (as it's optional and otherwise creates some problems with CRDs).