### PR TITLE
all: Use new `#LatestVersion` from thema

### DIFF
--- a/kindcat_composable.cue
+++ b/kindcat_composable.cue
@@ -25,7 +25,6 @@ Composable: S={
 	// The name of the lineage is constrained to the name of the schema interface being implemented.
 // FIXME cuetsy currently gets confused by all the unifications - maybe openapi too. Do something like the following after thema separates joinSchema/constraint expression
 //	lineage: { joinSchema: schif.interface }
-//	lineage: { joinSchema: (schif.interface | *{}) }
 
 	lineageIsGroup: schif.group
 }

--- a/kindcats.cue
+++ b/kindcats.cue
@@ -69,7 +69,7 @@ _sharedKind: {
 
 	// currentVersion is computed to be the syntactic version number of the latest
 	// schema in lineage.
-	currentVersion: thema.#SyntacticVersion & (thema.#LatestVersion & {lin: lineage}).out
+	currentVersion: lineage.#LatestVersion
 
 	maturity: Maturity
 


### PR DESCRIPTION
grafana/thema#82 changed `#LatestVersion` from a top-level property in the library to one within `#Lineage`. This broke our usage here, but the fix is trivial.