### PR TITLE
Introduce hacky support for kind composition

### DIFF
--- a/bind_composable.go
+++ b/bind_composable.go
@@ -1,12 +1,17 @@
 package kindsys
 
-import "github.com/grafana/thema"
+import (
+	"fmt"
+
+	"github.com/grafana/thema"
+)
 
 // genericComposable is a general representation of a parsed and validated
 // Composable kind.
 type genericComposable struct {
-	def Def[ComposableProperties]
-	lin thema.Lineage
+	def   Def[ComposableProperties]
+	lin   thema.Lineage
+	schif SchemaInterface
 }
 
 func (k genericComposable) Maturity() Maturity {
@@ -39,6 +44,10 @@ func (k genericComposable) Lineage() thema.Lineage {
 	return k.lin
 }
 
+func (k genericComposable) Implements() SchemaInterface {
+	return k.schif
+}
+
 // TODO docs
 func BindComposable(rt *thema.Runtime, def Def[ComposableProperties], opts ...thema.BindOption) (Composable, error) {
 	lin, err := def.Some().BindKindLineage(rt, opts...)
@@ -46,8 +55,14 @@ func BindComposable(rt *thema.Runtime, def Def[ComposableProperties], opts ...th
 		return nil, err
 	}
 
+	schif, err := FindSchemaInterface(def.Properties.SchemaInterface)
+	if err != nil {
+		panic(fmt.Sprintf("unreachable - got %s as string name for schema interface which should have been rejected by declarative validation", def.Properties.SchemaInterface))
+	}
+
 	return genericComposable{
-		def: def,
-		lin: lin,
+		def:   def,
+		lin:   lin,
+		schif: schif,
 	}, nil
 }

--- a/bind_core.go
+++ b/bind_core.go
@@ -1,7 +1,8 @@
 package kindsys
 
 import (
-	"sync"
+	"fmt"
+	"sort"
 
 	"github.com/grafana/thema"
 )
@@ -14,7 +15,6 @@ type genericCore struct {
 
 	// map of string name of slot to the currently composed contents of the slot
 	composed map[string][]Composable
-	cmut     sync.RWMutex
 }
 
 func (k genericCore) Validate(b []byte, codec Decoder) error {
@@ -66,55 +66,49 @@ func (k genericCore) Lineage() thema.Lineage {
 }
 
 func (k genericCore) Compose(slot Slot, kinds ...Composable) (Core, error) {
-	// TODO implement composition generically once we can fully describe a slot declaratively
-	return nil, &ErrNoSlotInKind{
-		Slot: slot,
-		Kind: k,
+	// first, check that this kind supports this slot
+	if k.def.Properties.Slots[slot.Name] != slot {
+		return nil, &ErrNoSlotInKind{
+			Slot: slot,
+			Kind: k,
+		}
 	}
 
-	// first, check that this kind supports this slot
-	// if k.def.Properties.Slots[slot.Name] != slot {
-	// 	return nil, &ErrNoSlotInKind{
-	// 		Slot: slot,
-	// 		Kind: k,
-	// 	}
-	// }
-	//
-	// schif, err := FindSchemaInterface(slot.SchemaInterface)
-	// if err != nil {
-	// 	panic(fmt.Sprintf("unreachable - slot was for nonexistent schema interface %s which should have been rejected at bind time", slot.SchemaInterface))
-	// }
-	//
-	// // then check that all provided kinds are implementors of the slot
-	// for _, kind := range kinds {
-	// 	if kind.Implements().Name() != schif.Name() {
-	// 		return nil, &ErrKindDoesNotImplementInterface{
-	// 			Kind:      kind,
-	// 			Interface: schif,
-	// 		}
-	// 	}
-	// }
-	//
-	// // Inputs look good. Make a copy with our built-up compose map
-	// com := make(map[string][]Composable)
-	// for k, v := range k.composed {
-	// 	com[k] = v
-	// }
-	//
-	// var all []Composable
-	// copy(all, com[slot.Name])
-	// all = append(all, kinds...)
-	// // Sort to ensure deterministic output of validation error messages, etc.
-	// sort.Slice(all, func(i, j int) bool {
-	// 	return all[i].Name() < all[j].Name()
-	// })
-	// com[slot.Name] = all
-	//
-	// return genericCore{
-	// 	def:      k.def,
-	// 	lin:      k.lin,
-	// 	composed: com,
-	// }, nil
+	schif, err := FindSchemaInterface(slot.SchemaInterface)
+	if err != nil {
+		panic(fmt.Sprintf("unreachable - slot was for nonexistent schema interface %s which should have been rejected at bind time", slot.SchemaInterface))
+	}
+
+	// then check that all provided kinds are implementors of the slot
+	for _, kind := range kinds {
+		if kind.Implements().Name() != schif.Name() {
+			return nil, &ErrKindDoesNotImplementInterface{
+				Kind:      kind,
+				Interface: schif,
+			}
+		}
+	}
+
+	// Inputs look good. Make a copy with our built-up compose map
+	com := make(map[string][]Composable)
+	for k, v := range k.composed {
+		com[k] = v
+	}
+
+	var all []Composable
+	copy(all, com[slot.Name])
+	all = append(all, kinds...)
+	// Sort to ensure deterministic output of validation error messages, etc.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Name() < all[j].Name()
+	})
+	com[slot.Name] = all
+
+	return genericCore{
+		def:      k.def,
+		lin:      k.lin,
+		composed: com,
+	}, nil
 }
 
 // TODO docs

--- a/bind_core.go
+++ b/bind_core.go
@@ -1,6 +1,10 @@
 package kindsys
 
 import (
+	"fmt"
+	"sort"
+	"sync"
+
 	"github.com/grafana/thema"
 )
 
@@ -9,6 +13,10 @@ import (
 type genericCore struct {
 	def Def[CoreProperties]
 	lin thema.Lineage
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]Composable
+	cmut     sync.RWMutex
 }
 
 func (k genericCore) Validate(b []byte, codec Decoder) error {
@@ -57,6 +65,58 @@ func (k genericCore) Def() Def[CoreProperties] {
 
 func (k genericCore) Lineage() thema.Lineage {
 	return k.lin
+}
+
+func (k genericCore) Compose(slot Slot, kinds ...Composable) (Core, error) {
+	// TODO implement composition generically once we can fully describe a slot declaratively
+	// return nil, &ErrNoSlotInKind{
+	// 	Slot: slot,
+	// 	Kind: k,
+	// }
+
+	// first, check that this kind supports this slot
+	if k.def.Properties.Slots[slot.Name] != slot {
+		return nil, &ErrNoSlotInKind{
+			Slot: slot,
+			Kind: k,
+		}
+	}
+
+	schif, err := FindSchemaInterface(slot.SchemaInterface)
+	if err != nil {
+		panic(fmt.Sprintf("unreachable - slot was for nonexistent schema interface %s which should have been rejected at bind time", slot.SchemaInterface))
+	}
+
+	// then check that all provided kinds are implementors of the slot
+	for _, kind := range kinds {
+		if kind.Implements().Name() != schif.Name() {
+			return nil, &ErrKindDoesNotImplementInterface{
+				Kind:      kind,
+				Interface: schif,
+			}
+		}
+	}
+
+	// Inputs look good. Make a copy with our built-up compose map
+	com := make(map[string][]Composable)
+	for k, v := range k.composed {
+		com[k] = v
+	}
+
+	var all []Composable
+	copy(all, com[slot.Name])
+	all = append(all, kinds...)
+	// Sort to ensure deterministic output of validation error messages, etc.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Name() < all[j].Name()
+	})
+	com[slot.Name] = all
+
+	return genericCore{
+		def:      k.def,
+		lin:      k.lin,
+		composed: com,
+	}, nil
 }
 
 // TODO docs

--- a/bind_core.go
+++ b/bind_core.go
@@ -1,8 +1,6 @@
 package kindsys
 
 import (
-	"fmt"
-	"sort"
 	"sync"
 
 	"github.com/grafana/thema"
@@ -69,54 +67,54 @@ func (k genericCore) Lineage() thema.Lineage {
 
 func (k genericCore) Compose(slot Slot, kinds ...Composable) (Core, error) {
 	// TODO implement composition generically once we can fully describe a slot declaratively
-	// return nil, &ErrNoSlotInKind{
-	// 	Slot: slot,
-	// 	Kind: k,
-	// }
+	return nil, &ErrNoSlotInKind{
+		Slot: slot,
+		Kind: k,
+	}
 
 	// first, check that this kind supports this slot
-	if k.def.Properties.Slots[slot.Name] != slot {
-		return nil, &ErrNoSlotInKind{
-			Slot: slot,
-			Kind: k,
-		}
-	}
-
-	schif, err := FindSchemaInterface(slot.SchemaInterface)
-	if err != nil {
-		panic(fmt.Sprintf("unreachable - slot was for nonexistent schema interface %s which should have been rejected at bind time", slot.SchemaInterface))
-	}
-
-	// then check that all provided kinds are implementors of the slot
-	for _, kind := range kinds {
-		if kind.Implements().Name() != schif.Name() {
-			return nil, &ErrKindDoesNotImplementInterface{
-				Kind:      kind,
-				Interface: schif,
-			}
-		}
-	}
-
-	// Inputs look good. Make a copy with our built-up compose map
-	com := make(map[string][]Composable)
-	for k, v := range k.composed {
-		com[k] = v
-	}
-
-	var all []Composable
-	copy(all, com[slot.Name])
-	all = append(all, kinds...)
-	// Sort to ensure deterministic output of validation error messages, etc.
-	sort.Slice(all, func(i, j int) bool {
-		return all[i].Name() < all[j].Name()
-	})
-	com[slot.Name] = all
-
-	return genericCore{
-		def:      k.def,
-		lin:      k.lin,
-		composed: com,
-	}, nil
+	// if k.def.Properties.Slots[slot.Name] != slot {
+	// 	return nil, &ErrNoSlotInKind{
+	// 		Slot: slot,
+	// 		Kind: k,
+	// 	}
+	// }
+	//
+	// schif, err := FindSchemaInterface(slot.SchemaInterface)
+	// if err != nil {
+	// 	panic(fmt.Sprintf("unreachable - slot was for nonexistent schema interface %s which should have been rejected at bind time", slot.SchemaInterface))
+	// }
+	//
+	// // then check that all provided kinds are implementors of the slot
+	// for _, kind := range kinds {
+	// 	if kind.Implements().Name() != schif.Name() {
+	// 		return nil, &ErrKindDoesNotImplementInterface{
+	// 			Kind:      kind,
+	// 			Interface: schif,
+	// 		}
+	// 	}
+	// }
+	//
+	// // Inputs look good. Make a copy with our built-up compose map
+	// com := make(map[string][]Composable)
+	// for k, v := range k.composed {
+	// 	com[k] = v
+	// }
+	//
+	// var all []Composable
+	// copy(all, com[slot.Name])
+	// all = append(all, kinds...)
+	// // Sort to ensure deterministic output of validation error messages, etc.
+	// sort.Slice(all, func(i, j int) bool {
+	// 	return all[i].Name() < all[j].Name()
+	// })
+	// com[slot.Name] = all
+	//
+	// return genericCore{
+	// 	def:      k.def,
+	// 	lin:      k.lin,
+	// 	composed: com,
+	// }, nil
 }
 
 // TODO docs

--- a/bind_custom.go
+++ b/bind_custom.go
@@ -67,6 +67,14 @@ func (k genericCustom) Lineage() thema.Lineage {
 	return k.lin
 }
 
+func (k genericCustom) Compose(slot Slot, kinds ...Composable) (Custom, error) {
+	// TODO implement composition generically once we can fully describe a slot declaratively
+	return nil, &ErrNoSlotInKind{
+		Slot: slot,
+		Kind: k,
+	}
+}
+
 // BindCustom creates a Custom-implementing type from a def, runtime, and opts
 //
 //nolint:lll

--- a/bind_custom.go
+++ b/bind_custom.go
@@ -1,6 +1,9 @@
 package kindsys
 
 import (
+	"fmt"
+	"sort"
+
 	"github.com/grafana/thema"
 )
 
@@ -9,6 +12,9 @@ import (
 type genericCustom struct {
 	def Def[CustomProperties]
 	lin thema.Lineage
+
+	// map of string name of slot to the currently composed contents of the slot
+	composed map[string][]Composable
 }
 
 func (k genericCustom) FromBytes(b []byte, codec Decoder) (*UnstructuredResource, error) {
@@ -68,11 +74,49 @@ func (k genericCustom) Lineage() thema.Lineage {
 }
 
 func (k genericCustom) Compose(slot Slot, kinds ...Composable) (Custom, error) {
-	// TODO implement composition generically once we can fully describe a slot declaratively
-	return nil, &ErrNoSlotInKind{
-		Slot: slot,
-		Kind: k,
+	// first, check that this kind supports this slot
+	if k.def.Properties.Slots[slot.Name] != slot {
+		return nil, &ErrNoSlotInKind{
+			Slot: slot,
+			Kind: k,
+		}
 	}
+
+	schif, err := FindSchemaInterface(slot.SchemaInterface)
+	if err != nil {
+		panic(fmt.Sprintf("unreachable - slot was for nonexistent schema interface %s which should have been rejected at bind time", slot.SchemaInterface))
+	}
+
+	// then check that all provided kinds are implementors of the slot
+	for _, kind := range kinds {
+		if kind.Implements().Name() != schif.Name() {
+			return nil, &ErrKindDoesNotImplementInterface{
+				Kind:      kind,
+				Interface: schif,
+			}
+		}
+	}
+
+	// Inputs look good. Make a copy with our built-up compose map
+	com := make(map[string][]Composable)
+	for k, v := range k.composed {
+		com[k] = v
+	}
+
+	var all []Composable
+	copy(all, com[slot.Name])
+	all = append(all, kinds...)
+	// Sort to ensure deterministic output of validation error messages, etc.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Name() < all[j].Name()
+	})
+	com[slot.Name] = all
+
+	return genericCustom{
+		def:      k.def,
+		lin:      k.lin,
+		composed: com,
+	}, nil
 }
 
 // BindCustom creates a Custom-implementing type from a def, runtime, and opts

--- a/compose.go
+++ b/compose.go
@@ -1,0 +1,23 @@
+package kindsys
+
+import "fmt"
+
+// ErrNoSlotInKind indicates that it was attempted to [Kind.Compose] into a
+// [Slot] for a [Kind] that defines no such slot.
+type ErrNoSlotInKind struct {
+	Slot Slot
+	Kind Kind
+}
+
+func (e *ErrNoSlotInKind) Error() string {
+	return fmt.Sprintf("no slot named %s in kind %s", e.Slot.Name, e.Kind.Name())
+}
+
+type ErrKindDoesNotImplementInterface struct {
+	Kind      Composable
+	Interface SchemaInterface
+}
+
+func (e *ErrKindDoesNotImplementInterface) Error() string {
+	return fmt.Sprintf("Composable kind %s does not implement schema interface %s", e.Kind.Name(), e.Interface.name)
+}

--- a/encoding/kubernetes.go
+++ b/encoding/kubernetes.go
@@ -213,6 +213,7 @@ func (k *KubernetesJSONDecoder) Decode(bytes []byte) (GrafanaShapeBytes, error) 
 		Labels:            kubeMeta.Labels,
 		CreationTimestamp: kubeMeta.CreationTimestamp.Time.UTC(),
 		Finalizers:        kubeMeta.Finalizers,
+		ExtraFields:       make(map[string]any),
 	}
 	if kubeMeta.OwnerReferences != nil && len(kubeMeta.OwnerReferences) > 0 {
 		cmd.ExtraFields["ownerReferences"] = kubeMeta.OwnerReferences
@@ -230,9 +231,9 @@ func (k *KubernetesJSONDecoder) Decode(bytes []byte) (GrafanaShapeBytes, error) 
 	cmd.UpdateTimestamp, _ = time.Parse(time.RFC3339, kubeMeta.Annotations[annotationPrefix+"updateTimestamp"])
 
 	// TODO deletions commented for now, but the question about whether to leave them is kinda fundamental to converting between kubernetes and grafana shapes
-	//delete(kubeMeta.Annotations, annotationPrefix+"updatedBy")
-	//delete(kubeMeta.Annotations, annotationPrefix+"createdBy")
-	//delete(kubeMeta.Annotations, annotationPrefix+"updateTimestamp")
+	// delete(kubeMeta.Annotations, annotationPrefix+"updatedBy")
+	// delete(kubeMeta.Annotations, annotationPrefix+"createdBy")
+	// delete(kubeMeta.Annotations, annotationPrefix+"updateTimestamp")
 
 	// For all other annotation keys which begin with annotationPrefix (grafana.com/), strip the prefix and put them in custom metadata
 	customMeta := make(map[string]any)
@@ -246,7 +247,7 @@ func (k *KubernetesJSONDecoder) Decode(bytes []byte) (GrafanaShapeBytes, error) 
 			// We've already handled this one
 			continue
 		}
-		//delete(kubeMeta.Annotations, key)
+		// delete(kubeMeta.Annotations, key)
 		customMeta[tkey] = val
 	}
 	// With annotations keys trimmed out of the original, we can add it to extra fields in common metadata

--- a/kind.go
+++ b/kind.go
@@ -172,6 +172,15 @@ type Core interface {
 	// ToBytes takes a []byte and a decoder, validates it against schema, and
 	// if validation is successful, unmarshals it into an UnstructuredResource.
 	// ToBytes(UnstructuredResource, codec Encoder) ([]byte, error)
+
+	// Compose takes a set of Composable kinds that fulfill a particular
+	// SchemaInterface and constructs a new Core with the provided composable kinds
+	// injected into the composition slot specified in the receiving Core kind's
+	// definition.
+	//
+	// The returned Core's Validate and Translate methods will trigger these
+	// methods for all the composed kinds.
+	Compose(slot Slot, kinds ...Composable) (Core, error)
 }
 
 // Custom is the dynamically typed runtime representation of a Grafana custom kind
@@ -189,6 +198,15 @@ type Custom interface {
 	// Def returns a wrapper around the underlying CUE value that represents the
 	// loaded and validated kind definition.
 	Def() Def[CustomProperties]
+
+	// Compose takes a set of Composable kinds that fulfill a particular
+	// SchemaInterface and constructs a new Custom with the provided composable kinds
+	// injected into the composition slot specified in the receiving Custom kind's
+	// definition.
+	//
+	// The returned Custom's Validate and Translate methods will trigger these
+	// methods for all the composed kinds.
+	Compose(slot Slot, kinds ...Composable) (Custom, error)
 }
 
 // Composable is the untyped runtime representation of a Grafana core kind definition.
@@ -201,6 +219,10 @@ type Composable interface {
 	// Def returns a wrapper around the underlying CUE value that represents the
 	// loaded and validated kind definition.
 	Def() Def[ComposableProperties]
+
+	// Implements returns the [SchemaInterface] that is implemented by this Composable
+	// kind.
+	Implements() SchemaInterface
 }
 
 // TypedCore is the statically typed runtime representation of a Grafana core
@@ -217,6 +239,9 @@ type TypedCore[R Resource] interface {
 	// TypeFromBytes is the same as [Core.FromBytes], but returns an instance of the
 	// associated generic struct type instead of an [UnstructuredResource].
 	TypeFromBytes(b []byte, codec Decoder) (R, error)
+
+	// TODO these too
+	// TypedCompose(slot Slot, kinds ...Composable) (TypedCore[R], error)
 }
 
 // TypedCustom is the statically typed runtime representation of a Grafana core kind definition.
@@ -233,6 +258,9 @@ type TypedCustom[R Resource] interface {
 	// TypeFromBytes is the same as [Custom.FromBytes], but returns an instance of the
 	// associated generic struct type instead of an [UnstructuredResource].
 	TypeFromBytes(b []byte, codec Decoder) (R, error)
+
+	// TODO these too
+	// TypedCompose(slot Slot, kinds ...Composable) (TypedCustom[R], error)
 }
 
 // Decoder takes a []byte representing a serialized resource and decodes it into

--- a/kindcat_custom.cue
+++ b/kindcat_custom.cue
@@ -105,6 +105,7 @@ _crdSchema: {
 // kinds - the same API patterns (and clients) used to interact with k8s CustomResources.
 Custom: S={
 	_sharedKind
+	_resourceKind
 
 	// group is the unique identifier of owner/grouping of this Custom kind
 	group: =~"^([a-z][a-z0-9-]*[a-z0-9])$"

--- a/kindcats.cue
+++ b/kindcats.cue
@@ -80,11 +80,23 @@ _sharedKind: {
 }
 
 // properties shared by all kinds that represent a complete object from root (i.e., not composable)
-_rootKind: {
+// TODO collapse Core and Custom into just ResourceKind, then we can get rid of this
+_resourceKind: {
 	// description is a brief narrative description of the nature and purpose of the kind.
 	// The contents of this field is shown to end users. Prefer clear, concise wording
 	// with minimal jargon.
 	description: nonEmptyString
+
+	// slots defines this resource kind's set of slots into which Composable kinds can be dynamically injected.
+	slots?: [N=string]: #Slot & { name: N }
+}
+
+#Slot: {
+	// Name is the string that uniquely identifies this slot within the kind.
+	name: string
+	// schemaInterface is the string name of the schema interface that this slot accepts.
+	schemaInterface: or([ for k, _ in schemaInterfaces {k} ])
+	// TODO to actually express these in kind defs we need to take more props. For now we've sloppy-hardcoded dashboard stuff in Go impl, lollll
 }
 
 // Maturity indicates the how far a given kind definition is in its initial
@@ -96,7 +108,7 @@ Maturity: "merged" | "experimental" | "stable" | "mature"
 // and datasources, are represented as core kinds.
 Core: S=close({
 	_sharedKind
-	_rootKind
+	_resourceKind
 
 	lineage: { name: S.machineName, joinSchema: _crdSchema }
 	lineageIsGroup: false

--- a/props.go
+++ b/props.go
@@ -28,7 +28,7 @@ type CoreProperties struct {
 		Scope       string `json:"scope"`
 		DummySchema bool   `json:"dummySchema"`
 	} `json:"crd"`
-	Slots map[string]Slot `json:"slots"`
+	Slots map[string]Slot `json:"slots,omitempty"`
 }
 
 func (m CoreProperties) _private() {}
@@ -53,7 +53,7 @@ type CustomProperties struct {
 		Frontend bool `json:"frontend"`
 		Backend  bool `json:"backend"`
 	} `json:"codegen"`
-	Slots map[string]Slot `json:"slots"`
+	Slots map[string]Slot `json:"slots,omitempty"`
 }
 
 // Slot describes a single composition slot defined in a Core or Custom kind.

--- a/props.go
+++ b/props.go
@@ -28,6 +28,7 @@ type CoreProperties struct {
 		Scope       string `json:"scope"`
 		DummySchema bool   `json:"dummySchema"`
 	} `json:"crd"`
+	Slots map[string]Slot `json:"slots"`
 }
 
 func (m CoreProperties) _private() {}
@@ -52,6 +53,17 @@ type CustomProperties struct {
 		Frontend bool `json:"frontend"`
 		Backend  bool `json:"backend"`
 	} `json:"codegen"`
+	Slots map[string]Slot `json:"slots"`
+}
+
+// Slot describes a single composition slot defined in a Core or Custom kind.
+type Slot struct {
+	// Name is the string that uniquely identifies this slot within the kind.
+	Name string `json:"name"`
+
+	// SchemaInterface is the string name of the schema interface that this slot
+	// accepts.
+	SchemaInterface string `json:"schemaInterface"`
 }
 
 func (m CustomProperties) _private() {}


### PR DESCRIPTION
This PR introduces (hacky! early!) support for composition of `Composable` kinds into `Resource` kinds.

The eventual goal is that we can describe kind composition declaratively in enough detail that all the work of doing composed validation can be handled generically here in the base kind implementations provided by kindsys. Doing so is prerequisite to doing full, composed validation on the apiserver, rather than having to rely webhooks (which would get pretty noisy).

For now, though, the implementations have to be hardcoded per-kind. I'm pulling up a corresponding PR in Grafana that does that for dashboards.